### PR TITLE
Enable scrolling through available tags 

### DIFF
--- a/config.cmake
+++ b/config.cmake
@@ -178,6 +178,10 @@ enable-tags-click = false
 enable-tags-scroll = false
 ; If true and enable-tags-scroll = true, scrolling will view all tags regardless if occupied
 tags-scroll-empty = false
+; If true and enable-tags-scroll = true, scrolling will cycle through tags backwards
+tags-scroll-reverse = false
+; If true and enable-tags-scroll = true, wrap active tag when scrolling
+tags-scroll-wrap = false
 ; Left-click to set secondary layout, right-click to switch to previous layout
 enable-layout-click = false
 ; Scroll to cycle between available layouts

--- a/config.cmake
+++ b/config.cmake
@@ -176,6 +176,8 @@ format = <label-tags> <label-layout> <label-floating> <label-title>
 enable-tags-click = false
 ; Scroll to cycle between available tags
 enable-tags-scroll = false
+; If true and enable-tags-scroll = true, scrolling will view all tags regardless if occupied
+tags-scroll-empty = false
 ; Left-click to set secondary layout, right-click to switch to previous layout
 enable-layout-click = false
 ; Scroll to cycle between available layouts

--- a/config.cmake
+++ b/config.cmake
@@ -174,6 +174,8 @@ format = <label-tags> <label-layout> <label-floating> <label-title>
 
 ; Left-click to view tag, right-click to toggle tag view
 enable-tags-click = false
+; Scroll to cycle between available tags
+enable-tags-scroll = false
 ; Left-click to set secondary layout, right-click to switch to previous layout
 enable-layout-click = false
 ; Scroll to cycle between available layouts

--- a/include/modules/dwm.hpp
+++ b/include/modules/dwm.hpp
@@ -229,6 +229,20 @@ namespace modules {
      */
     const dwmipc::Layout* prev_layout(const dwmipc::Layout& layout, bool wrap) const;
 
+	 /**
+     * Get the address of the next tag in m_tags or return NULL if not applicable
+     *
+     * @param ignore_empty Ignore empty tags
+     */
+    auto next_scrollable_tag(bool ignore_empty) const -> const tag_t*;
+
+    /**
+     * Get the address of the prev tag in m_tags or return NULL if not applicable
+     *
+     * @param ignore_empty Ignore empty tags
+     */
+    auto prev_scrollable_tag(bool ignore_empty) const -> const tag_t*;
+
     /**
      * Check if the command matches the specified IPC command name and if so,
      * parse and send the command to dwm
@@ -273,6 +287,11 @@ namespace modules {
 	  * If true, scrolling the bar cycles through the available tags
 	  */ 
     bool m_tags_scroll{false};
+
+	 /**
+	  * If true, scrolling will view all tags regardless if occupied
+	  */ 
+    bool m_tags_scroll_empty{false};
 
     /**
      * If true, scrolling the layout will wrap around to the beginning

--- a/include/modules/dwm.hpp
+++ b/include/modules/dwm.hpp
@@ -234,14 +234,14 @@ namespace modules {
      *
      * @param ignore_empty Ignore empty tags
      */
-    auto next_scrollable_tag(bool ignore_empty) const -> const tag_t*;
+    const tag_t* next_scrollable_tag(bool ignore_empty) const;
 
     /**
      * Get the address of the prev tag in m_tags or return NULL if not applicable
      *
      * @param ignore_empty Ignore empty tags
      */
-    auto prev_scrollable_tag(bool ignore_empty) const -> const tag_t*;
+    const tag_t* prev_scrollable_tag(bool ignore_empty) const;
 
     /**
      * Check if the command matches the specified IPC command name and if so,
@@ -287,6 +287,16 @@ namespace modules {
 	  * If true, scrolling the bar cycles through the available tags
 	  */ 
     bool m_tags_scroll{false};
+
+	 /**
+	  * If true, scrolling the bar cycles through the available tags backwards
+	  */ 
+    bool m_tags_scroll_reverse{false};
+
+	 /**
+	  * If true, wrap tag when scrolling
+	  */ 
+    bool m_tags_scroll_wrap{false};
 
 	 /**
 	  * If true, scrolling will view all tags regardless if occupied

--- a/include/modules/dwm.hpp
+++ b/include/modules/dwm.hpp
@@ -272,7 +272,7 @@ namespace modules {
 	 /**
 	  * If true, scrolling the bar cycles through the available tags
 	  */ 
-    bool m_tags_scroll{true};
+    bool m_tags_scroll{false};
 
     /**
      * If true, scrolling the layout will wrap around to the beginning

--- a/include/modules/dwm.hpp
+++ b/include/modules/dwm.hpp
@@ -269,6 +269,11 @@ namespace modules {
      */
     bool m_layout_scroll{true};
 
+	 /**
+	  * If true, scrolling the bar cycles through the available tags
+	  */ 
+    bool m_tags_scroll{true};
+
     /**
      * If true, scrolling the layout will wrap around to the beginning
      */

--- a/src/modules/dwm.cpp
+++ b/src/modules/dwm.cpp
@@ -413,7 +413,13 @@ namespace modules {
         [this](const tag_t& tag) { return m_bar_mon->tag_state.selected & tag.bit_mask; });
     if (current_tag_it != m_tags.end()) {
       auto prev = current_tag_it == m_tags.begin() ? current_tag_it : current_tag_it - 1;
-      if (m_tags_scroll_wrap && current_tag_it == m_tags.begin()) {
+      if (m_tags_scroll_wrap &&
+          // if tag is the first tag
+          (current_tag_it == m_tags.begin() ||
+              // or tag is the first non empty tag
+              (ignore_empty && &(*std::find_if(m_tags.begin(), m_tags.end(), [](const tag_t& tag) {
+                return tag.state != state_t::EMPTY;
+              })) == &(*current_tag_it)))) {
         // wrap the tag
         prev = m_tags.end() - 1;
       }


### PR DESCRIPTION
Enable scrolling through available tags by scrolling on the window title bar

Setting
```
; Scroll to cycle between available tags
enable-tags-scroll = false
```

Takes into account `label-empty ` hiding empty tags